### PR TITLE
Python 2.6 and partial Python 3 compatibility 

### DIFF
--- a/jsondiff.py
+++ b/jsondiff.py
@@ -239,20 +239,20 @@ def _item_replaced(path, key, info, item):
     info.insert(_op_replace(path, key, item))
 
 def _compare_dicts(path, info, src, dst):
-    added_keys = dst.viewkeys() - src.viewkeys()
-    removed_keys = src.viewkeys() - dst.viewkeys()
+    added_keys = set(dst.keys()) - set(src.keys())
+    removed_keys = set(src.keys()) - set(dst.keys())
     for key in removed_keys:
         _item_removed(path, str(key), info, src[key])
     for key in added_keys:
         _item_added(path, str(key), info, dst[key])
-    for key in src.viewkeys() & dst.viewkeys():
+    for key in set(src.keys()) & set(dst.keys()):
         _compare_values(path, key, info, src[key], dst[key])
 
 def _compare_lists(path, info, src, dst):
     len_src, len_dst = len(src), len(dst)
     max_len = max(len_src, len_dst)
     min_len = min(len_src, len_dst)
-    for key in xrange(max_len):
+    for key in range(max_len):
         if key < min_len:
             old, new = src[key], dst[key]
             if old == new:

--- a/jsondiff.py
+++ b/jsondiff.py
@@ -23,7 +23,7 @@ SOFTWARE.
 '''
 
 
-__all__ = ["make",] 
+__all__ = ["make",]
 
 def _store_index(a, x, v):
     lo = 0
@@ -96,7 +96,7 @@ class _compare_info(object):
                     curr = curr[1][1]
                     continue
             yield curr[2].get()
-            curr = curr[1]   
+            curr = curr[1]
 
 class _op_base(object):
     def __init__(self, path, key, value):
@@ -192,7 +192,7 @@ class _op_move(object):
 
     def get(self):
         return {'op': 'move', 'path': _path_join(self.path, self.key), 'from': _path_join(self.oldpath, self.oldkey)}
-    
+
     def __repr__(self):
         return str(self.get())
 


### PR DESCRIPTION
These changes make jsondiff.py much more usable on Python 3 and completely usable on Python 2.6.

I tested it with my fork of [python-json-patch](https://github.com/stefankoegl/python-json-patch). As you (of course) know, its jsonpatch generation mechanisms are poor, so I tried using it with `jsondiff.py`: https://github.com/selurvedu/python-json-patch/commit/981c76431981d3431c176dfdfeb1d197dda5e471.

Look at [build 5](https://travis-ci.org/selurvedu/python-json-patch/builds/85280494) and [build 6](https://travis-ci.org/selurvedu/python-json-patch/builds/85476566) and compare them. Never mind the error mentioning Coverage on Python 3.2 (it is certainly not related to `jsondiff.py`) and those errors saying `AssertionError: 2 != 1`, look at other ones. Errors mentioning `viewkeys` are gone, even though one type of errors is still present on Python 3: `TypeError: unorderable types`. I'm going to create a separate, more detailed issue about it.
