### PR TITLE
Use unicode() instead of str() on Python 2

### DIFF
--- a/jsondiff.py
+++ b/jsondiff.py
@@ -28,9 +28,11 @@ __all__ = ["make",]
 
 if sys.version_info[0] >= 3:
     _range = range
+    _str = str
     _viewkeys = dict.keys
 else:
     _range = xrange
+    _str = unicode
     if sys.version_info[1] >= 7:
         _viewkeys = dict.viewkeys
     else:
@@ -118,7 +120,7 @@ class _op_base(object):
         self.value = value
 
     def __repr__(self):
-        return str(self.get())
+        return _str(self.get())
 
 class _op_add(_op_base):
     def _on_undo_remove(self, path, key):
@@ -207,11 +209,11 @@ class _op_move(object):
         return {'op': 'move', 'path': _path_join(self.path, self.key), 'from': _path_join(self.oldpath, self.oldkey)}
 
     def __repr__(self):
-        return str(self.get())
+        return _str(self.get())
 
 def _path_join(path, key):
     if key != None:
-        return path + '/' + str(key).replace('~', '~0').replace('/', '~1')
+        return path + '/' + _str(key).replace('~', '~0').replace('/', '~1')
     return path
 
 def _item_added(path, key, info, item):
@@ -257,9 +259,9 @@ def _compare_dicts(path, info, src, dst):
     added_keys = dst_keys - src_keys
     removed_keys = src_keys - dst_keys
     for key in removed_keys:
-        _item_removed(path, str(key), info, src[key])
+        _item_removed(path, _str(key), info, src[key])
     for key in added_keys:
-        _item_added(path, str(key), info, dst[key])
+        _item_added(path, _str(key), info, dst[key])
     for key in src_keys & dst_keys:
         _compare_values(path, key, info, src[key], dst[key])
 


### PR DESCRIPTION
Fixes a testcase introduced in stefankoegl/python-json-patch@5d1980d (release >= v1.10).

Test results for Python 2.7:
[v1.9 with jsondiff](https://travis-ci.org/selurvedu/python-json-patch/jobs/121601408) – no testcase, no problem.
[v1.11 with jsondiff](https://travis-ci.org/selurvedu/python-json-patch/jobs/121601541) – testcase throws an error.
[v1.12 with jsondiff](https://travis-ci.org/selurvedu/python-json-patch/jobs/121601928) – same here.
[v1.12 with jsondiff and this patch](https://travis-ci.org/selurvedu/python-json-patch/jobs/121601970) – testcase passes.

Unfortunately, v1.13 introduces a new testcase which suffers from #4:
[v1.13 with jsondiff](https://travis-ci.org/selurvedu/python-json-patch/jobs/121601981)
[v1.13 with jsondiff and this patch](https://travis-ci.org/selurvedu/python-json-patch/jobs/121601992)

BTW, releases of python-json-patch with jsondiff (versions 1.9, 1.11, 1.12 and 1.13) are available here: https://github.com/selurvedu/python-json-patch/releases. Later I'm also going to add prebuilt eggs, wheels and tarballs.
